### PR TITLE
remove ctrl-c because #5

### DIFF
--- a/keymaps/case-switch.cson
+++ b/keymaps/case-switch.cson
@@ -8,7 +8,7 @@
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
 'atom-workspace':
-  "ctrl-c ctrl-t": 'case-switch:toggle'
-  "ctrl-c ctrl-c": "case-switch:convert-to-camel-case"
-  "ctrl-c ctrl-s": "case-switch:convert-to-snake-case"
-  "ctrl-c ctrl-h": "case-switch:convert-to-hyphen-case"
+  "alt-c ctrl-t": 'case-switch:toggle'
+  "alt-c ctrl-c": "case-switch:convert-to-camel-case"
+  "alt-c ctrl-s": "case-switch:convert-to-snake-case"
+  "alt-c ctrl-k": "case-switch:convert-to-kebab-case"


### PR DESCRIPTION
i did not check for conflicts but this should be better than it was. Hyphen case is also called kebab case.
